### PR TITLE
Update source.dart  -- animepahe.si added

### DIFF
--- a/dart/anime/src/en/animepahe/source.dart
+++ b/dart/anime/src/en/animepahe/source.dart
@@ -1,12 +1,12 @@
 import '../../../../../model/source.dart';
 
 Source get animepaheSource => _animepaheSource;
-const _animepaheVersion = "0.0.75";
+const _animepaheVersion = "0.0.80";
 const _animepaheSourceCodeUrl =
     "https://raw.githubusercontent.com/kodjodevf/mangayomi-extensions/$branchName/dart/anime/src/en/animepahe/animepahe.dart";
 Source _animepaheSource = Source(
   name: "AnimePahe",
-  baseUrl: "https://www.animepahe.ru",
+  baseUrl: "https://www.animepahe.si",
   lang: "en",
   typeSource: "single",
   iconUrl:


### PR DESCRIPTION
- replaced animepahe.ru with animepahe.si since domain has changed. 

- https://animepahe.si is now the primary domain according to official animepahe site.