### PR TITLE
Update animepahe.dart. Add new animepahe.si domain

### DIFF
--- a/dart/anime/src/en/animepahe/animepahe.dart
+++ b/dart/anime/src/en/animepahe/animepahe.dart
@@ -376,11 +376,12 @@ class AnimePahe extends MProvider {
         title: "Preferred domain",
         summary: "",
         valueIndex: 1,
-        entries: ["animepahe.com", "animepahe.ru", "animepahe.org"],
+        entries: ["animepahe.com", "animepahe.ru", "animepahe.org", "animepahe.si"],
         entryValues: [
           "https://animepahe.com",
           "https://animepahe.ru",
           "https://animepahe.org",
+          "https://animepahe.si",
         ],
       ),
       SwitchPreferenceCompat(


### PR DESCRIPTION
- Animepahe.ru no longer works. Updated to have Animepahe.si